### PR TITLE
Fix nightly updates

### DIFF
--- a/.github/workflows/fetch.yml
+++ b/.github/workflows/fetch.yml
@@ -8,8 +8,8 @@ jobs:
     name: Fetch the data
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
       - run: pip3 install -r requirements.txt
@@ -18,7 +18,7 @@ jobs:
       - name: Commit the data
         uses: nick-invision/retry@v2
         with:
-          timeout_seconds: 10
+          timeout_seconds: 30
           max_attempts: 5
           command: |
             git config --global user.name 'Pierre Mesure (Github Actions)'


### PR DESCRIPTION
- Increase the timeout for the "Commit" step. With many files, it timed out occasionally.
- Update GitHub Actions dependencies. Not required, but it has to be done sooner or later.
- Ubuntu 22.04 has new OpenSSL, which is too strict for FTI's website. Based on urllib3/urllib3#2653